### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/darksky.gemspec
+++ b/darksky.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ruby gem for retrieving data from the Dark Sky API}
   s.description = %q{Ruby gem for retrieving data from the Dark Sky API}
 
-  s.rubyforge_project = "darksky"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.